### PR TITLE
Supporting hostinterface.get API

### DIFF
--- a/hostinterface.go
+++ b/hostinterface.go
@@ -1,0 +1,125 @@
+package zabbix
+
+import "fmt"
+
+const (
+	// HostinterfaceMainNotDefault indicates that the interface is not used
+	// as default on the host.
+	HostinterfaceMainNotDefault = 0
+
+	// HostinterfaceMainDefault indicates that the interface is used as
+	// default on the host.
+	HostinterfaceMainDefault = 1
+)
+
+const (
+	// HostinterfaceTypeDefault is possible to returned value
+	HostinterfaceTypeDefault = 0
+
+	// HostinterfaceTypeAgent indicates that the interface type is agent.
+	HostinterfaceTypeAgent = 1
+
+	// HostinterfaceTypeSNMP indicates that the interface type is SNMP.
+	HostinterfaceTypeSNMP = 2
+
+	// HostinterfaceTypeIPMI indicates that the interface type is SNMP.
+	HostinterfaceTypeIPMI = 3
+
+	// HostinterfaceTypeJMX indicates that the interface type is SNMP.
+	HostinterfaceTypeJMX = 4
+)
+
+const (
+	// HostinterfaceUseipDNS indicates that connection using host DNS name.
+	HostinterfaceUseipDNS = 0
+
+	// HostinterfaceUseipAddress indeicates that connection using host IP
+	// address.
+	HostinterfaceUseipAddress = 1
+)
+
+// Hostinterface represents a Zabbix Hostinterface returned from the Zabbix API.
+//
+// See: https://www.zabbix.com/documentation/2.2/manual/api/reference/hostinterface/object
+type Hostinterface struct {
+	// InterfaceID is ID of the interface.
+	InterfaceID string
+
+	// DNS is DNS name used by the interface.
+	DNS string
+
+	// HostID is ID of the host the interface belongs to.
+	HostID string
+
+	// IP is IP address used by the interface.
+	IP string
+
+	// Main shows that the interface is used as default on the host.
+	Main int
+
+	// Port is port number used by the interface. Can contain user macros.
+	Port string
+
+	// Type is interface type.
+	Type int
+
+	// Useip shows that the connection using host DNS name or IP address.
+	Useip int
+}
+
+// HostinterfaceGetParams represent the parameters for a `hostinterface.get` API call.
+//
+// See: https://www.zabbix.com/documentation/2.2/manual/api/reference/hostinterface/get#parameters
+type HostinterfaceGetParams struct {
+	GetParameters
+
+	// HostIDs filters search result to hostinterfaces that matched the
+	// given Host IDs.
+	HostIDs []string `json:"hostids,omitempty"`
+
+	// InterfaceIDs filters search result to hostinterfaces that matched the
+	// given Interface IDs.
+	InterfaceIDs []string `json:"interfaceids,omitempty"`
+
+	// ItemIDs filters search result to hostinterfaces that matched the
+	// given Item IDs.
+	ItemIDs []string `json:"itemids,omitempty"`
+
+	// TriggerIDs filters search result to hostinterfaces that matched the
+	// given Trigger IDs.
+	TriggerIDs []string `json:"triggerids,omitempty"`
+
+	SelectItems SelectQuery `json:"selectItems,omitempty"`
+
+	SelectHosts SelectQuery `json:"selectHosts,omitempty"`
+}
+
+// GetHostinterfaces queries the Zabbix API for Host Interfaces matching the
+// given search parameter.
+//
+// ErrEventNotFound is returned if the search result set is empty.
+// An error is returned if a transport, parsing or API error occurs.
+func (c *Session) GetHostinterfaces(params HostinterfaceGetParams) ([]Hostinterface, error) {
+	hostinterfaces := make([]jHostinterface, 0)
+	err := c.Get("hostinterface.get", params, &hostinterfaces)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(hostinterfaces) == 0 {
+		return nil, ErrNotFound
+	}
+
+	// map JSON Events to Go Events
+	out := make([]Hostinterface, len(hostinterfaces))
+	for i, jhostinterface := range hostinterfaces {
+		hostinterface, err := jhostinterface.Hostinterface()
+		if err != nil {
+			return nil, fmt.Errorf("Error mapping Hostinterface %d in response: %v", i, err)
+		}
+
+		out[i] = *hostinterface
+	}
+
+	return out, nil
+}

--- a/hostinterface_json.go
+++ b/hostinterface_json.go
@@ -1,0 +1,53 @@
+package zabbix
+
+import "fmt"
+
+// jHostinterface is a private map for the Zabbix API Hostinterface object.
+// See: https://www.zabbix.com/documentation/2.2/manual/api/reference/hostinterface/object
+type jHostinterface struct {
+	InterfaceID string `json:"interfaceid"`
+	DNS         string `json:"dns"`
+	HostID      string `json:"hostid"`
+	IP          string `json:"ip"`
+	Main        int    `json:"main,string"`
+	Port        string `json:"port"`
+	Type        int    `json:"type,string"`
+	Useip       int    `json:"useip,string"`
+}
+
+// Hostinterface returns a native Go Hostinterface struct mapped from the given
+// JSON Hostinterface data.
+func (c *jHostinterface) Hostinterface() (*Hostinterface, error) {
+	hostinterface := &Hostinterface{}
+	hostinterface.InterfaceID = c.InterfaceID
+	hostinterface.DNS = c.DNS
+	hostinterface.HostID = c.HostID
+	hostinterface.IP = c.IP
+	hostinterface.Main = c.Main
+	hostinterface.Port = c.Port
+	hostinterface.Type = c.Type
+	hostinterface.Useip = c.Useip
+
+	return hostinterface, nil
+}
+
+// jHostinterfaces is a slice of jHostinterface structs.
+type jHostinterfaces []jHostinterface
+
+func (c jHostinterfaces) Hostinterface() ([]Hostinterface, error) {
+	if c != nil {
+		hostinterfaces := make([]Hostinterface, len(c))
+		for i, jhostinterface := range c {
+			hostinterface, err := jhostinterface.Hostinterface()
+			if err != nil {
+				return nil, fmt.Errorf("Error unmarshalling Hostinterface %d in JSON data: %v", i, err)
+			}
+
+			hostinterfaces[i] = *hostinterface
+		}
+
+		return hostinterfaces, nil
+	}
+
+	return nil, nil
+}

--- a/hostinterfaces_test.go
+++ b/hostinterfaces_test.go
@@ -1,0 +1,45 @@
+package zabbix
+
+import (
+	"testing"
+)
+
+func TestHostinterfaces(t *testing.T) {
+	session := GetTestSession(t)
+
+	params := HostinterfaceGetParams{}
+
+	hostinterfaces, err := session.GetHostinterfaces(params)
+
+	if err != nil {
+		t.Fatalf("Error getting hostinterfaces: %v", err)
+	}
+
+	if len(hostinterfaces) == 0 {
+		t.Fatalf("No hostinterfaces found")
+	}
+
+	for i, hostinterface := range hostinterfaces {
+		if hostinterface.HostID == "" {
+			t.Fatalf("Hostinterface %d returned in response body has no HostID", i)
+		}
+		if hostinterface.InterfaceID == "" {
+			t.Fatalf("Hostinterface %d returned in response body has no InterfaceID", i)
+		}
+		switch hostinterface.Main {
+		case 0, 1:
+		default:
+			t.Fatalf("Hostinterface %d returned in response body has invalid Hostinterface Main value: %v", i, hostinterface.Main)
+		}
+		switch hostinterface.Type {
+		case 0, 1, 2, 3, 4:
+		default:
+			t.Fatalf("Hostinterface %d returned in response body has invalid Hostinterface Type value: %v", i, hostinterface.Type)
+		}
+		switch hostinterface.Useip {
+		case 0, 1:
+		default:
+			t.Fatalf("Hostinterface %d returned in response body has invalid Hostinterface Useip value: %v", i, hostinterface.Useip)
+		}
+	}
+}


### PR DESCRIPTION
1. type property can be 0. But according to Zabbix official API reference,
   it only be 1~4. I have no idea.
2. hostinterface object has "bulk" property since Zabbix 3.0. It is not
   implemented.