### PR TITLE
Add support to authenticate with a session token

### DIFF
--- a/client_builder_test.go
+++ b/client_builder_test.go
@@ -76,6 +76,16 @@ func TestSessionCache(t *testing.T) {
 	}
 }
 
+func TestWithSessionToken(t *testing.T) {
+	session, err := CreateClient(fakeURL).WithSessionToken(fakeToken).Connect()
+	if err != nil {
+		t.Error("failed to create session with SessionToken", err)
+	}
+	if err := compareSessionWithMock(session); err != nil {
+		t.Error(err)
+	}
+}
+
 func compareSessionWithMock(session *Session) error {
 	if session.URL != fakeURL {
 		return fmt.Errorf("Session URL '%s' is not equal to '%s'", session.URL, fakeURL)


### PR DESCRIPTION
Zabbix uses authentication tokens (Request.AuthToken). 
With ClientBuilder.WithSessionToken(token) you can inject an existing token directly into the session.
So you lose the need to know credentials.