### PR TITLE
Update Zabbix API auth process to 6.4 and over

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,3 +90,4 @@ Released under the [GNU GPL License](https://github.com/miraclelinux/go-zabbix/b
 - Add `proxy.get`
 - Add `hostinterface.get`
 - Remove cover.run link from README.md
+- Add support for authorization via HTTP header for API versions >= 6.4


### PR DESCRIPTION
Starting from Zabbix 6.4, the method of passing the authorization token via the JSON parameter "auth" is deprecated. Instead, it is now passed via the HTTP "Authorization" header, with the authorization token itself preceded by the word "Bearer". Continuing to pass the authorization token as a JSON parameter with API versions 6.4 or greater results in deprecation warnings.